### PR TITLE
Mac architecture fixup

### DIFF
--- a/02-make-macos.sh
+++ b/02-make-macos.sh
@@ -2,18 +2,20 @@
 set -e
 PAT_ROOT="../pat"
 VERSION=$(grep "Version =" ${PAT_ROOT}/internal/buildinfo/VERSION.go|cut -d '"' -f2)
+ARCH=$(go env GOARCH)
 
 if [ $(go env GOOS) != "darwin" ]; then
 	echo "This step must be run on macOS" && exit 1
 fi
-if [ ! $(command -v packagesbuild >/dev/null 2>&1) ]; then
+if ! $(command -v packagesbuild >/dev/null 2>&1) ; then
 	echo "WhiteBox Packages must be installed" && exit 1
 fi
 (cd ${PAT_ROOT}; ./make.bash;)
 
 if [ -d $SIGNING_KEY ]; then
 	echo "WARNING: No SIGNING_KEY set. Using unsigned pkg for distribution."
-	cp ${PAT_ROOT}/pat_${VERSION}_darwin_amd64_unsigned.pkg dists/pat_${VERSION}_darwin_amd64.pkg
+	mkdir -p dists
+	cp ${PAT_ROOT}/pat_${VERSION}_darwin_${ARCH}_unsigned.pkg dists/pat_${VERSION}_darwin_${ARCH}.pkg
 else
-	productsign --sign "${SIGNING_KEY}" ${PAT_ROOT}/pat_${VERSION}_darwin_amd64_unsigned.pkg dists/pat_${VERSION}_darwin_amd64.pkg
+	productsign --sign "${SIGNING_KEY}" ${PAT_ROOT}/pat_${VERSION}_darwin_${ARCH}_unsigned.pkg dists/pat_${VERSION}_darwin_${ARCH}.pkg
 fi


### PR DESCRIPTION
* Parameterize architecture to account for `arm64` (requires https://github.com/la5nta/pat/pull/336)
* Apparently line 9 is not a boolean, so no square brackets
* Make `dists` if it's not already made